### PR TITLE
Bump version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,4 +28,4 @@ jobs:
         cat $HOME/.config/nix/nix.conf
     - name: Run the doctests in a nix-shell
       run: |
-        nix-shell --run "cabal repl --with-ghc=doctest"
+        nix-shell --run "cabal build && cabal test"

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,10 @@
 
 `benri-hspec` uses [PVP Versioning][1].
 
+## 0.1.0.2 -- 2024-02-28
+
+* Reformated, enabled doctests by default
+
 
 ## 0.1.0.1 -- 2022-12-23
 

--- a/benri-hspec.cabal
+++ b/benri-hspec.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               benri-hspec
-version:            0.1.0.1
+version:            0.1.0.2
 synopsis:           Simplify tests where Either or Maybe types are returned from monadic code
 description:
   A small library of __convenient__ functions for writing hspec tests.
@@ -61,7 +61,7 @@ test-suite readme
 
 Flag use-doc-tests
   description: Include the doctests in the package tests
-  default:     False
+  default:     True
 
 test-suite doctests
   if flag(use-doc-tests)

--- a/cabal.project
+++ b/cabal.project
@@ -1,5 +1,3 @@
 packages: .
 
-
-package benri-hspec
-  flags: +use-doc-tests
+write-ghc-environment-files: always


### PR DESCRIPTION
Also:
- enable doctests by default (so they can be run on hackage)
- test doctests using cabal test on CI